### PR TITLE
RS-4069 Added support to change DB through JS migration

### DIFF
--- a/flyway-core/pom.xml
+++ b/flyway-core/pom.xml
@@ -175,9 +175,9 @@
           <optional>true</optional>
         </dependency>
         <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-data-mongodb</artifactId>
-          <version>1.3.6.RELEASE</version>
+          <groupId>org.springframework.data</groupId>
+          <artifactId>spring-data-mongodb</artifactId>
+          <version>1.9.5.RELEASE</version>
           <optional>true</optional>
         </dependency>
         <dependency>

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/FlywayConfiguration.java
@@ -18,6 +18,8 @@ package org.flywaydb.core.api.configuration;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.resolver.MigrationResolver;
 
+import java.util.Map;
+
 /**
  * Readonly interface for main flyway configuration. Can be used to provide configuration data to migrations and callbacks.
  */
@@ -66,6 +68,34 @@ public interface FlywayConfiguration {
      * @return Whether default built-in callbacks should be skipped. (default: false)
      */
     boolean isSkipDefaultCallbacks();
+
+    /**
+     * Checks whether placeholders should be replaced.
+     *
+     * @return Whether placeholders should be replaced. (default: true)
+     */
+    boolean isPlaceholderReplacement();
+
+    /**
+     * Retrieves the suffix of every placeholder.
+     *
+     * @return The suffix of every placeholder. (default: } )
+     */
+    String getPlaceholderSuffix();
+
+    /**
+     * Retrieves the prefix of every placeholder.
+     *
+     * @return The prefix of every placeholder. (default: ${ )
+     */
+    String getPlaceholderPrefix();
+
+    /**
+     * Retrieves the map of &lt;placeholder, replacementValue&gt; to apply to sql migration scripts.
+     *
+     * @return The map of &lt;placeholder, replacementValue&gt; to apply to sql migration scripts.
+     */
+    Map<String, String> getPlaceholders();
 
 	/**
      * Retrieves the target version up to which Flyway should consider migrations.

--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/SQLFlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/SQLFlywayConfiguration.java
@@ -93,34 +93,6 @@ public interface SQLFlywayConfiguration extends FlywayConfiguration {
 	String getSqlMigrationPrefix();
 
 	/**
-	 * Checks whether placeholders should be replaced.
-	 *
-	 * @return Whether placeholders should be replaced. (default: true)
-	 */
-	boolean isPlaceholderReplacement();
-
-	/**
-	 * Retrieves the suffix of every placeholder.
-	 *
-	 * @return The suffix of every placeholder. (default: } )
-	 */
-	String getPlaceholderSuffix();
-
-	/**
-	 * Retrieves the prefix of every placeholder.
-	 *
-	 * @return The prefix of every placeholder. (default: ${ )
-	 */
-	String getPlaceholderPrefix();
-
-	/**
-	 * Retrieves the map of &lt;placeholder, replacementValue&gt; to apply to sql migration scripts.
-	 *
-	 * @return The map of &lt;placeholder, replacementValue&gt; to apply to sql migration scripts.
-	 */
-	Map<String, String> getPlaceholders();
-
-	/**
 	 * Retrieves the schemas managed by Flyway.  These schema names are case-sensitive.
 	 * <p>Consequences:</p>
 	 * <ul>

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/callback/MongoScriptFlywayCallback.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/callback/MongoScriptFlywayCallback.java
@@ -23,6 +23,7 @@ import org.flywaydb.core.api.configuration.MongoFlywayConfiguration;
 import org.flywaydb.core.internal.dbsupport.MongoScript;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Locations;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.logging.Log;
 import org.flywaydb.core.internal.util.logging.LogFactory;
 import org.flywaydb.core.internal.util.scanner.Resource;
@@ -65,11 +66,14 @@ public class MongoScriptFlywayCallback extends MongoFlywayCallback {
     /**
      * Creates a new instance.
      *
-     * @param scanner          The Scanner for loading migrations on the classpath.
-     * @param locations        The locations where migrations are located.
-     * @param configuration    The Mongo configuration object
+     * @param scanner               The Scanner for loading migrations on the classpath.
+     * @param locations             The locations where migrations are located.
+     * @param placeholderReplacer   The placeholder replacer to use.
+     * @param configuration         The Mongo configuration object
      */
-    public MongoScriptFlywayCallback(Scanner scanner, Locations locations, MongoFlywayConfiguration configuration) {
+    public MongoScriptFlywayCallback(Scanner scanner, Locations locations,
+                                     PlaceholderReplacer placeholderReplacer,
+                                     MongoFlywayConfiguration configuration) {
         super(configuration);
         String encoding = configuration.getEncoding();
         String mongoMigrationSuffix = configuration.getMongoMigrationSuffix();
@@ -97,7 +101,7 @@ public class MongoScriptFlywayCallback extends MongoFlywayCallback {
                                 "-> " + existing.getResource().getLocationOnDisk() + "\n" +
                                 "-> " + resource.getLocationOnDisk());
                     }
-                    scripts.put(key, new MongoScript(resource, encoding, databaseName));
+                    scripts.put(key, new MongoScript(resource, encoding, databaseName, placeholderReplacer));
                 }
             }
         }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/MongoStatement.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/dbsupport/MongoStatement.java
@@ -30,14 +30,21 @@ public class MongoStatement {
     private String json;
 
     /**
+     * The database name where this mongo statement will be applied.
+     */
+    private String dbName;
+
+    /**
      * Creates a new MongoStatement.
      *
      * @param lineNumber The original line number where the statement was located in the script it came from.
      * @param json  JSON string related with this MongoStatement.
+     * @param dbName the database name where this statement will be applied.
      */
-    public MongoStatement(int lineNumber, String json) {
+    public MongoStatement(int lineNumber, String json, String dbName) {
         this.lineNumber = lineNumber;
         this.json = json;
+        this.dbName = dbName;
     }
 
     /**
@@ -54,4 +61,10 @@ public class MongoStatement {
         return json;
     }
 
+    /**
+     * @return The database name where this mongo statement will be applied.
+     */
+    public String getDbName() {
+        return dbName;
+    }
 }

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MongoMetaDataTable.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/metadatatable/MongoMetaDataTable.java
@@ -24,7 +24,7 @@ import com.mongodb.client.result.UpdateResult;
 import org.bson.Document;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.MigrationType;
-import org.flywaydb.core.internal.dbsupport.mongo.MongoDatabaseUtil;
+import org.flywaydb.core.internal.util.MongoDatabaseUtil;
 import org.flywaydb.core.internal.util.logging.Log;
 import org.flywaydb.core.internal.util.logging.LogFactory;
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMongoMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/CompositeMongoMigrationResolver.java
@@ -25,6 +25,7 @@ import org.flywaydb.core.internal.resolver.spring.SpringMongoMigrationResolver;
 import org.flywaydb.core.internal.util.FeatureDetector;
 import org.flywaydb.core.internal.util.Location;
 import org.flywaydb.core.internal.util.Locations;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Scanner;
 
 import java.util.ArrayList;
@@ -55,16 +56,18 @@ public class CompositeMongoMigrationResolver implements MigrationResolver {
 	 * @param scanner                      The Scanner for loading migrations on the classpath.
 	 * @param config                       The flyway instance containing Mongo relevant information.
 	 * @param locations                    The locations where migrations are located.
+     * @param placeholderReplacer          The placeholder replacer to use.
 	 * @param customMigrationResolvers     Custom Migration Resolvers.
 	 */
 	public CompositeMongoMigrationResolver(Scanner scanner, Locations locations, MongoFlywayConfiguration config,
+                                           PlaceholderReplacer placeholderReplacer,
                                            MigrationResolver... customMigrationResolvers) {
 		if (!config.isSkipDefaultResolvers()) {
 			String databaseName = config.getDatabaseName();
 			boolean springMongoAvailable = new FeatureDetector(scanner.getClassLoader()).isSpringMongoAvailable();
-			for (Location location : locations.getLocations()) {
+			for (Location location: locations.getLocations()) {
 				migrationResolvers.add(new MongoMigrationResolver(scanner, location, config));
-				migrationResolvers.add(new MongoScriptMigrationResolver(scanner, location, config));
+				migrationResolvers.add(new MongoScriptMigrationResolver(scanner, location, placeholderReplacer, config));
 						
 				if (springMongoAvailable) {
 					migrationResolvers.add(new SpringMongoMigrationResolver(databaseName, scanner, location, config));

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/mongoscript/MongoScriptMigrationExecutor.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/mongoscript/MongoScriptMigrationExecutor.java
@@ -18,6 +18,7 @@ package org.flywaydb.core.internal.resolver.mongoscript;
 import com.mongodb.MongoClient;
 import org.flywaydb.core.api.resolver.AbstractMongoMigrationExecutor;
 import org.flywaydb.core.internal.dbsupport.MongoScript;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Resource;
 
 public class MongoScriptMigrationExecutor extends AbstractMongoMigrationExecutor {
@@ -36,7 +37,12 @@ public class MongoScriptMigrationExecutor extends AbstractMongoMigrationExecutor
     /**
      * The database to use.
      */
-    private String databaseName;
+    private final String databaseName;
+
+    /**
+     * The placeholder replacer to apply to mongo js migration scripts.
+     */
+    private final PlaceholderReplacer placeholderReplacer;
 
     /**
      * Creates a new mongo javascript migration.
@@ -44,16 +50,21 @@ public class MongoScriptMigrationExecutor extends AbstractMongoMigrationExecutor
      * @param mongoScriptResource   The resource containing the MongoScript.
      * @param encoding              The encoding of this Javascript migration.
      * @param databaseName          The database name on which migration will be applied.
+     * @param placeholderReplacer   The placeholder replacer to apply to mongo js migration scripts.
      */
-    public MongoScriptMigrationExecutor(Resource mongoScriptResource, String encoding, String databaseName) {
+    public MongoScriptMigrationExecutor(Resource mongoScriptResource,
+                                        String encoding,
+                                        String databaseName,
+                                        PlaceholderReplacer placeholderReplacer) {
         this.mongoScriptResource = mongoScriptResource;
         this.encoding = encoding;
         this.databaseName = databaseName;
+        this.placeholderReplacer = placeholderReplacer;
     }
 
     @Override
     public void execute(MongoClient mongoClient) {
-        MongoScript mongoScript = new MongoScript(mongoScriptResource, encoding, databaseName);
+        MongoScript mongoScript = new MongoScript(mongoScriptResource, encoding, databaseName, placeholderReplacer);
         mongoScript.execute(mongoClient);
     }
 

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringMongoMigrationResolver.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/resolver/spring/SpringMongoMigrationResolver.java
@@ -102,7 +102,7 @@ public class SpringMongoMigrationResolver implements MigrationResolver {
 				migrations.add(migrationInfo);
 			}
 		} catch (Exception e) {
-			throw new FlywayException("Unable to resolve Spring Jdbc Java migrations in location: " + location, e);
+			throw new FlywayException("Unable to resolve Spring mongo Java migrations in location: " + location, e);
 		}
 
 		Collections.sort(migrations, new ResolvedMigrationComparator());

--- a/flyway-core/src/main/java/org/flywaydb/core/internal/util/MongoDatabaseUtil.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/internal/util/MongoDatabaseUtil.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.flywaydb.core.internal.dbsupport.mongo;
+package org.flywaydb.core.internal.util;
 
 import com.mongodb.MongoClient;
 import com.mongodb.MongoException;

--- a/flyway-core/src/test/java/org/flywaydb/core/MongoFlywayCallbackSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/MongoFlywayCallbackSmallTest.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.*;
 public class MongoFlywayCallbackSmallTest extends EmbeddedMongoDb {
 
     private static final String BASEDIR = "migration/subdir/dir1";
-    private static final String MONGO_PREFIX = "flyway.mongo.";
 
     protected MongoFlyway flyway;
     private MongoFlywayCallbackImpl callbackImpl;
@@ -40,9 +39,9 @@ public class MongoFlywayCallbackSmallTest extends EmbeddedMongoDb {
     @Before
     public void setup() throws Exception {
         Properties mongoProperties = new Properties();
-        mongoProperties.setProperty(MONGO_PREFIX + "locations", BASEDIR);
-        mongoProperties.setProperty(MONGO_PREFIX + "validateOnMigrate", "false");
-        mongoProperties.setProperty(MONGO_PREFIX + "uri", getMongoUri());
+        mongoProperties.setProperty("flyway.locations", BASEDIR);
+        mongoProperties.setProperty("flyway.validateOnMigrate", "false");
+        mongoProperties.setProperty("flyway.mongoUri", getMongoUri());
         callbackImpl = new MongoFlywayCallbackImpl(flyway);
         callbacks = new MongoFlywayCallback[]{callbackImpl};
         flyway = new MongoFlyway();

--- a/flyway-core/src/test/java/org/flywaydb/core/MongoFlywayMediumTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/MongoFlywayMediumTest.java
@@ -35,9 +35,9 @@ public class MongoFlywayMediumTest  extends EmbeddedMongoDb {
 
 	private MongoFlyway build() {
         Properties props = new Properties();
-        props.setProperty("flyway.mongo.locations", "db.migrations.mongo");
-        props.setProperty("flyway.mongo.validateOnMigrate", "false");
-        props.setProperty("flyway.mongo.uri", getMongoUri());
+        props.setProperty("flyway.locations", "db.migrations.mongo");
+        props.setProperty("flyway.validateOnMigrate", "false");
+        props.setProperty("flyway.mongoUri", getMongoUri());
 
 		MongoFlyway flyway = new MongoFlyway();
 		flyway.configure(props);

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/MongoScriptSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/MongoScriptSmallTest.java
@@ -61,7 +61,7 @@ public class MongoScriptSmallTest {
     }
 
     @Test
-    public void stripSqlCommentsMultiLineCommentMultipleLines() {
+    public void stripMongoCommentsMultiLineCommentMultipleLines() {
         lines.add("/*comment line");
         lines.add("more comment text*/");
         List<MongoStatement> mongoStatements = mongoScript.linesToStatements(lines);
@@ -70,6 +70,7 @@ public class MongoScriptSmallTest {
 
     @Test
     public void linesToStatements() {
+        lines.add("use(sample);");
         lines.add("db.runCommand({");
         lines.add("insert: 'sample',");
         lines.add("documents: [{item: 'pencil'}]");
@@ -80,8 +81,9 @@ public class MongoScriptSmallTest {
         assertEquals(1, mongoStatements.size());
 
         MongoStatement mongoStatement = mongoStatements.get(0);
-        assertEquals(1, mongoStatement.getLineNumber());
+        assertEquals(2, mongoStatement.getLineNumber());
         assertEquals("{insert: 'sample',documents: [{item: 'pencil'}]}", mongoStatement.getJson());
+        assertEquals("sample", mongoStatement.getDbName());
     }
 
     @Test

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/mongoscript/MongoScriptMigrationTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/dbsupport/mongoscript/MongoScriptMigrationTest.java
@@ -29,11 +29,12 @@ import org.flywaydb.core.api.MigrationType;
 import org.flywaydb.core.api.MigrationVersion;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.dbsupport.FlywayMongoScriptException;
-import org.flywaydb.core.internal.dbsupport.mongo.MongoDatabaseUtil;
+import org.flywaydb.core.internal.util.MongoDatabaseUtil;
 import org.flywaydb.core.internal.info.MigrationInfoDumper;
 import org.flywaydb.core.internal.resolver.MongoFlywayConfigurationForTests;
 import org.flywaydb.core.internal.resolver.mongoscript.MongoScriptMigrationResolver;
 import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.flywaydb.core.migration.MongoScriptMigrationTestCase;
 import org.junit.Test;
@@ -149,6 +150,7 @@ public class MongoScriptMigrationTest extends MongoScriptMigrationTestCase {
         MongoScriptMigrationResolver mongoScriptMigrationResolver = new MongoScriptMigrationResolver(
                 new Scanner(Thread.currentThread().getContextClassLoader()),
                 new Location(BASEDIR),
+                PlaceholderReplacer.NO_PLACEHOLDERS,
                 MongoFlywayConfigurationForTests.create());
         List<ResolvedMigration> migrations = mongoScriptMigrationResolver.resolveMigrations();
         for (ResolvedMigration migration : migrations) {

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/MongoFlywayConfigurationForTests.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/MongoFlywayConfigurationForTests.java
@@ -22,6 +22,8 @@ import org.flywaydb.core.api.configuration.MongoFlywayConfiguration;
 
 import com.mongodb.MongoClient;
 
+import java.util.Map;
+
 public class MongoFlywayConfigurationForTests implements MongoFlywayConfiguration {
 
 	private ClassLoader classLoader;
@@ -32,6 +34,7 @@ public class MongoFlywayConfigurationForTests implements MongoFlywayConfiguratio
     private String repeatableMongoMigrationPrefix;
 	private String mongoMigrationSeparator;
 	private String mongoMigrationSuffix;
+    private boolean skipDefaultResolvers;
 
 	public MongoFlywayConfigurationForTests(ClassLoader classLoader, String[] locations, String encoding, String dbName,
                                             String mongoMigrationPrefix, String repeatableMongoMigrationPrefix,
@@ -76,9 +79,13 @@ public class MongoFlywayConfigurationForTests implements MongoFlywayConfiguratio
 		return null;
 	}
 
+    public void setSkipDefaultResolvers(boolean skipDefaultResolvers) {
+        this.skipDefaultResolvers = skipDefaultResolvers;
+    }
+
 	@Override
 	public boolean isSkipDefaultResolvers() {
-		return false;
+        return skipDefaultResolvers;
 	}
 
 	public boolean isSkipDefaultCallbacks() {
@@ -114,6 +121,26 @@ public class MongoFlywayConfigurationForTests implements MongoFlywayConfiguratio
 	public String getMongoMigrationSuffix() {
 		return mongoMigrationSuffix;
 	}
+
+    @Override
+    public boolean isPlaceholderReplacement() {
+        return false;
+    }
+
+    @Override
+    public String getPlaceholderSuffix() {
+        return null;
+    }
+
+    @Override
+    public String getPlaceholderPrefix() {
+        return null;
+    }
+
+    @Override
+    public Map<String, String> getPlaceholders() {
+        return null;
+    }
 
 	@Override
 	public String getTable() {

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/mongoscript/MongoScriptMigrationResolverSmallTest.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/mongoscript/MongoScriptMigrationResolverSmallTest.java
@@ -18,6 +18,7 @@ package org.flywaydb.core.internal.resolver.mongoscript;
 import org.flywaydb.core.api.resolver.ResolvedMigration;
 import org.flywaydb.core.internal.resolver.MongoFlywayConfigurationForTests;
 import org.flywaydb.core.internal.util.Location;
+import org.flywaydb.core.internal.util.PlaceholderReplacer;
 import org.flywaydb.core.internal.util.scanner.Scanner;
 import org.flywaydb.core.internal.util.scanner.classpath.ClassPathResource;
 import org.flywaydb.core.internal.util.scanner.filesystem.FileSystemResource;
@@ -42,7 +43,9 @@ public class MongoScriptMigrationResolverSmallTest {
     public void resolveMigrations() {
         MongoScriptMigrationResolver mongoMigrationResolver =
                 new MongoScriptMigrationResolver(scanner,
-                        new Location("migration/subdir"), MongoFlywayConfigurationForTests.create());
+                                                 new Location("migration/subdir"),
+                                                 PlaceholderReplacer.NO_PLACEHOLDERS,
+                                                 MongoFlywayConfigurationForTests.create());
         Collection<ResolvedMigration> migrations = mongoMigrationResolver.resolveMigrations();
 
         assertEquals(3, migrations.size());
@@ -64,15 +67,20 @@ public class MongoScriptMigrationResolverSmallTest {
                 MongoFlywayConfigurationForTests.createWithPrefix("CheckValidate");
         configuration.setRepeatableMongoMigrationPrefix("X");
         MongoScriptMigrationResolver mongoMigrationResolver =
-                new MongoScriptMigrationResolver(scanner, new Location(""), configuration);
+                new MongoScriptMigrationResolver(scanner,
+                                                 new Location(""),
+                                                 PlaceholderReplacer.NO_PLACEHOLDERS,
+                                                 configuration);
         assertEquals(2, mongoMigrationResolver.resolveMigrations().size());
     }
 
     @Test
     public void resolveMigrationsNonExisting() {
         MongoScriptMigrationResolver mongoMigrationResolver =
-                new MongoScriptMigrationResolver(scanner, new Location("non/existing"),
-                        MongoFlywayConfigurationForTests.createWithPrefix("CheckValidate"));
+                new MongoScriptMigrationResolver(scanner,
+                                                 new Location("non/existing"),
+                                                 PlaceholderReplacer.NO_PLACEHOLDERS,
+                                                 MongoFlywayConfigurationForTests.createWithPrefix("CheckValidate"));
 
         mongoMigrationResolver.resolveMigrations();
     }
@@ -80,8 +88,10 @@ public class MongoScriptMigrationResolverSmallTest {
     @Test
     public void extractScriptName() {
         MongoScriptMigrationResolver mongoMigrationResolver =
-                new MongoScriptMigrationResolver(scanner, new Location("db/migration"),
-                        MongoFlywayConfigurationForTests.createWithPrefix("db_"));
+                new MongoScriptMigrationResolver(scanner,
+                                                 new Location("db/migration"),
+                                                 PlaceholderReplacer.NO_PLACEHOLDERS,
+                                                 MongoFlywayConfigurationForTests.createWithPrefix("db_"));
 
         assertEquals("db_0__init.js", mongoMigrationResolver.extractScriptName(
                 new ClassPathResource("db/migration/db_0__init.js", Thread.currentThread().getContextClassLoader())));
@@ -90,8 +100,10 @@ public class MongoScriptMigrationResolverSmallTest {
     @Test
     public void extractScriptNameRootLocation() {
         MongoScriptMigrationResolver mongoMigrationResolver =
-                new MongoScriptMigrationResolver(scanner, new Location(""),
-                        MongoFlywayConfigurationForTests.createWithPrefix("db_"));
+                new MongoScriptMigrationResolver(scanner,
+                                                 new Location(""),
+                                                 PlaceholderReplacer.NO_PLACEHOLDERS,
+                                                 MongoFlywayConfigurationForTests.createWithPrefix("db_"));
 
         assertEquals("db_0__init.js", mongoMigrationResolver.extractScriptName(
                 new ClassPathResource("db_0__init.js", Thread.currentThread().getContextClassLoader())));
@@ -100,8 +112,10 @@ public class MongoScriptMigrationResolverSmallTest {
     @Test
     public void extractScriptNameFileSystemPrefix() {
         MongoScriptMigrationResolver mongoMigrationResolver =
-                new MongoScriptMigrationResolver(scanner, new Location("filesystem:/some/dir"),
-                        MongoFlywayConfigurationForTests.create());
+                new MongoScriptMigrationResolver(scanner,
+                                                 new Location("filesystem:/some/dir"),
+                                                 PlaceholderReplacer.NO_PLACEHOLDERS,
+                                                 MongoFlywayConfigurationForTests.create());
 
         assertEquals("V3.171__patch.js",
                 mongoMigrationResolver.extractScriptName(new FileSystemResource("/some/dir/V3.171__patch.js")));

--- a/flyway-core/src/test/java/org/flywaydb/core/migration/MongoScriptMigrationTestCase.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/migration/MongoScriptMigrationTestCase.java
@@ -30,7 +30,6 @@ public abstract class MongoScriptMigrationTestCase extends EmbeddedMongoDb {
      * The base directory for the regular test migrations.
      */
     protected static final String BASEDIR = "migration/mongoscript";
-    protected static final String MONGO_PREFIX = "flyway.mongo.";
 
     protected MongoClient client;
     protected MongoFlyway flyway;
@@ -38,9 +37,9 @@ public abstract class MongoScriptMigrationTestCase extends EmbeddedMongoDb {
     @Before
     public void setUp() throws Exception {
         Properties mongoProperties = new Properties();
-        mongoProperties.setProperty(MONGO_PREFIX + "locations", BASEDIR);
-        mongoProperties.setProperty(MONGO_PREFIX + "validateOnMigrate", "false");
-        mongoProperties.setProperty(MONGO_PREFIX + "uri", getMongoUri());
+        mongoProperties.setProperty("flyway.locations", BASEDIR);
+        mongoProperties.setProperty("flyway.validateOnMigrate", "false");
+        mongoProperties.setProperty("flyway.mongoUri", getMongoUri());
         flyway = new MongoFlyway();
         flyway.configure(mongoProperties);
         client = getMongoClient();

--- a/flyway-mongo-sbt-largetest/src/test/java/org/flywaydb/sbt/largetest/MongoSbtLargeTest.java
+++ b/flyway-mongo-sbt-largetest/src/test/java/org/flywaydb/sbt/largetest/MongoSbtLargeTest.java
@@ -36,19 +36,19 @@ public class MongoSbtLargeTest extends EmbeddedMongoDb {
 
     @Test
     public void sysPropsOverride() throws Exception {
-        String stdOut = runSbt("test1", 0, "-Dflyway.mongo.locations=db/migration", "flywayClean", "flywayMigrate");
+        String stdOut = runSbt("test1", 0, "-Dflyway.locations=db/migration", "flywayClean", "flywayMigrate");
         assertTrue(stdOut.contains("Successfully applied 1 migration"));
     }
 
     @Test
     public void useTestScope() throws Exception {
-        String stdOut = runSbt("test1", 0, "-Dflyway.mongo.locations=filesystem:src/main/resources/db/migration,filesystem:src/test/resources/db/migration", "test:flywayClean", "test:flywayMigrate");
+        String stdOut = runSbt("test1", 0, "-Dflyway.locations=filesystem:src/main/resources/db/migration,filesystem:src/test/resources/db/migration", "test:flywayClean", "test:flywayMigrate");
         assertTrue(stdOut.contains("Successfully applied 2 migration"));
     }
 
     @Test
     public void flywayUrlAsSysProps() throws Exception {
-        String stdOut = runSbt("test2", 0, "-Dflyway.mongo.uri=mongodb://localhost:27016/flyway_sample", "flywayClean", "flywayMigrate");
+        String stdOut = runSbt("test2", 0, "-Dflyway.mongoUri=mongodb://localhost:27016/flyway_sample", "flywayClean", "flywayMigrate");
         assertTrue(stdOut.contains("Successfully applied 2 migration"));
     }
 

--- a/flyway-mongo-sbt-largetest/src/test/resources/test1/build.sbt
+++ b/flyway-mongo-sbt-largetest/src/test/resources/test1/build.sbt
@@ -13,8 +13,8 @@ resolvers += (
     "Local Maven Repository" at Path.userHome.asFile.toURI.toURL + ".m2/repository"
 )
 
-flywayUri := "mongodb://localhost:27016/flyway_sample"
+flywayMongoUri := "mongodb://localhost:27016/flyway_sample"
 
 flywayLocations += "db/sbt"
 
-flywayUri in Test := "mongodb://localhost:27016/flyway_sample"
+flywayMongoUri in Test := "mongodb://localhost:27016/flyway_sample"

--- a/flyway-mongo-sbt-largetest/src/test/resources/test2/build.sbt
+++ b/flyway-mongo-sbt-largetest/src/test/resources/test2/build.sbt
@@ -14,4 +14,4 @@ resolvers += (
 )
 
 // Wrong port specified here. Test should override this port with the correct one
-flywayUri := "mongodb://localhost:27018/flyway_sample"
+flywayMongoUri := "mongodb://localhost:27018/flyway_sample"

--- a/flyway-mongo-sbt/src/main/scala/org/flywaydb/sbt/MongoFlywayPlugin.scala
+++ b/flyway-mongo-sbt/src/main/scala/org/flywaydb/sbt/MongoFlywayPlugin.scala
@@ -25,7 +25,9 @@ import sbt.Keys._
 import sbt._
 import sbt.classpath._
 
-import scala.collection.JavaConversions.propertiesAsScalaMap
+import scala.collection.JavaConverters.mapAsScalaMapConverter
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+import scala.collection.JavaConverters.propertiesAsScalaMapConverter
 
 object MongoFlywayPlugin extends AutoPlugin {
 
@@ -37,7 +39,7 @@ object MongoFlywayPlugin extends AutoPlugin {
     // common migration settings for all tasks
     //*********************
 
-    val flywayUri = settingKey[String]("The Mongo URI to use to connect to the database.")
+    val flywayMongoUri = settingKey[String]("The Mongo URI to use to connect to the database.")
     val flywayTable = settingKey[String]("The name of the metadata table that will be used by Flyway.(default: schema_version)")
     val flywayBaselineVersion = settingKey[String]("The version to tag an existing schema with when executing baseline. (default: 1)")
     val flywayBaselineDescription = settingKey[String]("The description to tag an existing schema with " +
@@ -81,6 +83,10 @@ object MongoFlywayPlugin extends AutoPlugin {
       "to version 4.0 (unknown to us) has already been applied. Instead of bombing out (fail fast) with an exception, a warning is " +
       "logged and Flyway continues normally. This is useful for situations where one must be able to redeploy an older version of the " +
       "application after the database has been migrated by a newer one. (default: true)")
+    val flywayPlaceholderReplacement = settingKey[Boolean]("Whether placeholders should be replaced. (default: true)")
+    val flywayPlaceholders = settingKey[Map[String, String]]("A map of <placeholder, replacementValue> to apply to mongo js migration scripts.")
+    val flywayPlaceholderPrefix = settingKey[String]("The prefix of every placeholder. (default: ${ )")
+    val flywayPlaceholderSuffix = settingKey[String]("The suffix of every placeholder. (default: } )")
     val flywayBaselineOnMigrate = settingKey[Boolean]("Whether to automatically call baseline when migrate is executed against a " +
       "non-empty database with no metadata table. This database will then be baselined with the {@code baselineVersion} before " +
       "executing the migrations. Only migrations above {@code baselineVersion} will then be applied. This is useful for initial " +
@@ -116,7 +122,10 @@ object MongoFlywayPlugin extends AutoPlugin {
                                             skipDefaultCallbacks: Boolean)
   private case class ConfigMongoMigration(mongoMigrationPrefix: String, repeatableMongoMigrationPrefix: String,
                                           mongoMigrationSeparator: String, mongoMigrationSuffix: String)
-  private case class ConfigMigrate(ignoreFutureMigrations: Boolean, baselineOnMigrate: Boolean, validateOnMigrate: Boolean)
+  private case class ConfigMigrate(ignoreFutureMigrations: Boolean, placeholderReplacement: Boolean,
+                                   placeholders: Map[String, String], placeholderPrefix: String,
+                                   placeholderSuffix: String, baselineOnMigrate: Boolean,
+                                   validateOnMigrate: Boolean)
   private case class Config(base: ConfigBase, migrationLoading: ConfigMigrationLoading,
                             mongoMigration: ConfigMongoMigration, migrate: ConfigMigrate)
 
@@ -137,7 +146,7 @@ object MongoFlywayPlugin extends AutoPlugin {
     import autoImport._
     val defaults = new MongoFlyway()
     Seq[Setting[_]](
-      flywayUri := "",
+      flywayMongoUri := "",
       flywayLocations := List("filesystem:src/main/resources/db/migration"),
       flywayResolvers := Array.empty[String],
       flywaySkipDefaultResolvers := defaults.isSkipDefaultResolvers,
@@ -154,12 +163,16 @@ object MongoFlywayPlugin extends AutoPlugin {
       flywayCallbacks := new Array[String](0),
       flywaySkipDefaultCallbacks := defaults.isSkipDefaultCallbacks,
       flywayIgnoreFutureMigrations := defaults.isIgnoreFutureMigrations,
+      flywayPlaceholderReplacement := defaults.isPlaceholderReplacement,
+      flywayPlaceholders := defaults.getPlaceholders.asScala.toMap,
+      flywayPlaceholderPrefix := defaults.getPlaceholderPrefix,
+      flywayPlaceholderSuffix := defaults.getPlaceholderSuffix,
       flywayBaselineOnMigrate := defaults.isBaselineOnMigrate,
       flywayValidateOnMigrate := defaults.isValidateOnMigrate,
       flywayCleanOnValidationError := defaults.isCleanOnValidationError,
       flywayCleanDisabled := defaults.isCleanDisabled,
 
-      flywayConfigBase := ConfigBase(flywayUri.value, flywayTable.value, flywayBaselineVersion.value,
+      flywayConfigBase := ConfigBase(flywayMongoUri.value, flywayTable.value, flywayBaselineVersion.value,
         flywayBaselineDescription.value),
 
       flywayConfigMigrationLoading := ConfigMigrationLoading(flywayLocations.value, flywayResolvers.value,
@@ -172,6 +185,8 @@ object MongoFlywayPlugin extends AutoPlugin {
         flywayMongoMigrationSuffix.value),
 
       flywayConfigMigrate := ConfigMigrate(flywayIgnoreFutureMigrations.value,
+        flywayPlaceholderReplacement.value, flywayPlaceholders.value,
+        flywayPlaceholderPrefix.value, flywayPlaceholderSuffix.value,
         flywayBaselineOnMigrate.value, flywayValidateOnMigrate.value),
 
       flywayConfig := Config(flywayConfigBase.value, flywayConfigMigrationLoading.value,
@@ -186,9 +201,9 @@ object MongoFlywayPlugin extends AutoPlugin {
       },
 
       flywayInfo := withPrepared((fullClasspath in conf).value, streams.value) {
-          val info = MongoFlyway(flywayConfig.value).info()
-          streams.value.log.info(MigrationInfoDumper.dumpToAsciiTable(info.all()))
-          info
+        val info = MongoFlyway(flywayConfig.value).info()
+        streams.value.log.info(MigrationInfoDumper.dumpToAsciiTable(info.all()))
+        info
       },
 
       flywayRepair := withPrepared((fullClasspath in conf).value, streams.value) {
@@ -211,8 +226,8 @@ object MongoFlywayPlugin extends AutoPlugin {
   }
 
   /**
-   * Registers sbt log as a static logger for Flyway
-   */
+    * Registers sbt log as a static logger for Flyway
+    */
   private def registerAsFlywayLogger(streams: TaskStreams) {
     LogFactory.setLogCreator(SbtLogCreator)
     FlywaySbtLog.streams = Some(streams)
@@ -286,6 +301,9 @@ object MongoFlywayPlugin extends AutoPlugin {
 
     def configure(config: ConfigMigrate): MongoFlyway = {
       flyway.setIgnoreFutureMigrations(config.ignoreFutureMigrations)
+      flyway.setPlaceholders(config.placeholders.asJava)
+      flyway.setPlaceholderPrefix(config.placeholderPrefix)
+      flyway.setPlaceholderSuffix(config.placeholderSuffix)
       flyway.setBaselineOnMigrate(config.baselineOnMigrate)
       flyway.setValidateOnMigrate(config.validateOnMigrate)
       flyway
@@ -293,8 +311,8 @@ object MongoFlywayPlugin extends AutoPlugin {
 
     def configureSysProps(uri: String): MongoFlyway = {
       val props = new Properties()
-      val uriKey = "flyway.mongo.uri"
-      System.getProperties.filter { e => e._1.startsWith("flyway") }
+      val uriKey = "flyway.mongoUri"
+      System.getProperties.asScala.filter { e => e._1.startsWith("flyway") }
         .foreach { e => props.put(e._1, e._2) }
       if (!sys.props.contains(uriKey)) props.put(uriKey, uri)
       flyway.configure(props)
@@ -316,6 +334,5 @@ object MongoFlywayPlugin extends AutoPlugin {
       streams.foreach(_.log.error(message)); streams.foreach(_.log.trace(e))
     }
   }
+
 }
-
-

--- a/flyway-sample-mongodb/README.md
+++ b/flyway-sample-mongodb/README.md
@@ -8,6 +8,9 @@ user:~/.../flyway$ mvn exec:java -Dexec.mainClass=org.flywaydb.sample.mongodb.Ma
 ```
 
 ## JavaScript migrations
-Mongo migrations defined in JavaScript file are now supported. JS file should contain database run commands
-as defined [here](https://docs.mongodb.com/v3.2/reference/method/db.runCommand/) . Single line `//` and
-multi-line `/*..*/` comments can be added as well.
+Mongo migrations defined in JavaScript file are now supported.
+[Database run command](https://docs.mongodb.com/v3.2/reference/method/db.runCommand/) can be used to
+specify the changes. MongoFlyway is configured through MongoClientURI which must contain a
+database name. This is where metadata collection will be created. Available migrations will be applied
+on the database specified through Mongo URI, unless database is changed by using the `use(<dbName>)` command 
+in the JS file. Single line `//` and multi-line `/*..*/` comments can be added as well.

--- a/flyway-sample-mongodb/pom.xml
+++ b/flyway-sample-mongodb/pom.xml
@@ -27,9 +27,9 @@
           <optional>true</optional>
         </dependency>
         <dependency>
-          <groupId>org.springframework.boot</groupId>
-          <artifactId>spring-boot-starter-data-mongodb</artifactId>
-          <version>1.3.6.RELEASE</version>
+          <groupId>org.springframework.data</groupId>
+          <artifactId>spring-data-mongodb</artifactId>
+          <version>1.9.5.RELEASE</version>
           <optional>true</optional>
         </dependency>
     </dependencies>

--- a/flyway-sample-mongodb/src/main/java/org/flywaydb/sample/mongodb/Main.java
+++ b/flyway-sample-mongodb/src/main/java/org/flywaydb/sample/mongodb/Main.java
@@ -20,17 +20,16 @@ import org.flywaydb.core.MongoFlyway;
 import java.util.Properties;
 
 public class Main {
-	private static final String MONGO_PREFIX = "flyway.mongo.";
-	
-	public static void main(String[] args) throws Exception {
+
+    public static void main(String[] args) throws Exception {
         Properties props = new Properties();
         MongoFlyway mongoFlyway = new MongoFlyway();
 
-        props.setProperty(MONGO_PREFIX + "locations", "org.flywaydb.sample.mongodb.migrations, db/migration");
-        props.setProperty(MONGO_PREFIX + "validateOnMigrate", "false");
-        props.setProperty(MONGO_PREFIX + "uri", "mongodb://localhost:27017/db1");
+        props.setProperty("flyway.locations", "org.flywaydb.sample.mongodb.migrations, db/migration");
+        props.setProperty("flyway.validateOnMigrate", "false");
+        props.setProperty("flyway.mongoUri", "mongodb://localhost:27017/db1");
+        props.setProperty("flyway.placeholders.first_name", "Alice");
         mongoFlyway.configure(props);
-
         mongoFlyway.migrate();
 	}
 

--- a/flyway-sample-mongodb/src/main/resources/db/migration/V2_1__Add_users.js
+++ b/flyway-sample-mongodb/src/main/resources/db/migration/V2_1__Add_users.js
@@ -15,7 +15,7 @@
  */
 db.runCommand({
     insert: 'users',
-    documents: [{name: 'Alice', age: 2}]
+    documents: [{name: '${first_name}', age: 2}]
 });
 
 db.runCommand({
@@ -24,4 +24,9 @@ db.runCommand({
         {name: 'Bob'},
         {name: "Mallory"}
     ]
+});
+
+use(db2);
+db.runCommand({
+    create: 'sampleCollection'
 });


### PR DESCRIPTION
* Current database in scope can now be specified using the `use` command.
For example, `use(foo);` will change the current database in scope to
foo and the migrations followed by this command will be applied to
foo database.

* Moved MongoDatabaseUtil to package org.flywaydb.core.internal.util

* Changed MongoFlyway configuration keys and updated them in mongo sbt plugin