### PR TITLE
Single connection patch

### DIFF
--- a/flyway-core/src/main/java/org/flywaydb/core/api/configuration/SQLFlywayConfiguration.java
+++ b/flyway-core/src/main/java/org/flywaydb/core/api/configuration/SQLFlywayConfiguration.java
@@ -105,4 +105,8 @@ public interface SQLFlywayConfiguration extends FlywayConfiguration {
 	 */
 	String[] getSchemas();
 
+	/**
+	 * @return Whether to only use a single connection for both metadata table management and applying migrations.
+	 */
+	boolean isUseSingleConnection();
 }

--- a/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
+++ b/flyway-core/src/test/java/org/flywaydb/core/internal/resolver/FlywayConfigurationForTests.java
@@ -85,6 +85,10 @@ public class FlywayConfigurationForTests implements SQLFlywayConfiguration {
         this.skipDefaultCallbacks = skipDefaultCallbacks;
     }
 
+    public boolean isUseSingleConnection() {
+        return false;
+    }
+
     @Override
     public ClassLoader getClassLoader() {
         return classLoader;


### PR DESCRIPTION
Flyway now supports use of a single jdbc connection for metadata table management and
applying migrations. This feature is helpful in a situation where a migration takes
longer than the wait_timeout period. When this setting is set to false(default), migrations
that exceed the wait_timeout period will cause Flyway to crash due to the separate jdbc
connection for metadata table being shutdown.

The useSingleConnection property should be disabled for better performance.